### PR TITLE
Potential fix for process.env access

### DIFF
--- a/spotifyApi/shuffle/back/README.md
+++ b/spotifyApi/shuffle/back/README.md
@@ -15,9 +15,14 @@ Steps:
         - This can be installed with `npm install -g yarn`
         - It can be run with `yarn install`
 3. Create a .env file in the root directory
-    - Add "CLIENT_ID=" + any random string to it
-    - The text inside should look like: `CLIENT_ID=a209d8e4f`
+    - The text inside should look like:
+    ```
+    CLIENT_ID=a209d8e4f
+    NODE_ENV=production
+    ```
 4. Use the terminal command `tsc`
     - This will create a build folder
 5. Run the built files with `node ./build/_____.js`
-6. Your CLIENT_ID should be printed in the terminal
+    - You can try setting your environment up beforehand to cause Express.js to print its debug messages to the server's terminal: `DEBUG = express:*`
+6. All environment variables should be printed in the terminal and the page should respond with an error.
+    - Note that you can change .env's NODE_ENV value to *development* to cause the stack trace to be printed in the browser as well as the server's terminal.

--- a/spotifyApi/shuffle/back/src/env.d.ts
+++ b/spotifyApi/shuffle/back/src/env.d.ts
@@ -1,0 +1,37 @@
+/* This type declaration module defines the variables we
+expect to see in our environment by extending the
+NodeJS.ProcessEnv global interface.
+
+https://www.youtube.com/watch?v=FBZidnvNSUg
+
+Note that limiting a member to certain literal values
+only aids us when trying to change their values in
+code; VS-Code's autofill will provide these as options.
+This in no way prevents dotenv from loading bad values
+in from an .env file or the user from assigning bad
+values prior to launching the program in the terminal. */
+
+declare global {
+    namespace NodeJS {
+        interface ProcessEnv {
+            // Spotify Developer's App ID
+            CLIENT_ID: string
+
+            /* For setting the app into production mode
+            which disables Express's stack trace printing
+            on error */
+            NODE_ENV?: 'development' | 'production'
+
+            /* For setting which debug messages to print.
+            This must be set in the terminal before
+            launching a Node app; it can't be set by an
+            .env file.  Because of this, this declaration
+            is unncessary.  It is only kept here to serve
+            as a reminder of this functionality and for
+            the app to be able to check its value. */
+            DEBUG?: string
+        }
+    }
+}
+
+export {};

--- a/spotifyApi/shuffle/back/src/server.ts
+++ b/spotifyApi/shuffle/back/src/server.ts
@@ -1,50 +1,23 @@
 import dotenv from 'dotenv';
 import express from 'express';
 
-/* Adding type safety to this project causes some inconvenience
-- dotenv can't be loaded into its default process.env because
-  TypeScript doesn't have a global 'process' variable
-- A plain blank object can't be given to dotenv to populate because
-  TypeScript doesn't allow downstream code to reference Object
-  members that weren't explicitly declared
-  - To get around this, we must declare the type below.
-  - Making the members optional allows us to initiate it with an
-    empty object
-  - This allows us to then give an empty object to dotenv.config()
-  - It's probably possible to disable strict Object member
-    enforcement through some compiler setting, but then why even
-    use TS at that point? */
-type Environment = {
-    // Spotify Developer's App ID
-    CLIENT_ID?: string
-
-    // For enabling Express's debug output
-    DEBUG?: string
-
-    /* For setting the app into production mode which disables
-    Express's stack trace printing on error */
-    NODE_ENV?: string
-}
-const setEnv = (): Environment => {
-  let env: Environment = {};
-  let result = dotenv.config({
-    processEnv: env
-  });
-  if ('error' in result) {throw result.error;} else return env;
+const setEnv = (): void => {
+  let result = dotenv.config();
+  if ('error' in result) {throw result.error;}
 }
 
 const setRoutes = (): express.Router => {
   const router = express.Router();
 
   router.get('/', (req, res) => {
-    res.send("test string");
+    throw new Error('BROKEN');
   });
 
   return router;
 }
 
 async function run(): Promise<void> {
-    const env: Environment = setEnv();
+    setEnv();
 
     const app: express.Application = express();
     const PORT: number = 8081;
@@ -53,8 +26,12 @@ async function run(): Promise<void> {
     app.use(setRoutes());
 
     app.listen(PORT, () => {
-      console.log(`\nServer listening...\n${SERVER_URL}\nCient ID: ${env.CLIENT_ID}\n`);
+      console.log(`\nServer listening...\n${SERVER_URL}\n
+        Client ID: ${process.env.CLIENT_ID}
+        Node Env: ${process.env.NODE_ENV}
+        Debug: ${process.env.DEBUG}\n`
+      );
     });
 }
 
-run().catch(console.error);
+run();

--- a/spotifyApi/shuffle/back/tsconfig.json
+++ b/spotifyApi/shuffle/back/tsconfig.json
@@ -98,12 +98,13 @@
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
 
     /* Completeness */
     "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": ["src/*"]
 }


### PR DESCRIPTION
The workaround we had for dotenv variables was not good.  We need our variables to be in _process.env_ because there are dependencies that rely them being in that location specifically.  In this case, it was Express.js that relied on the NODE_ENV variable being here.